### PR TITLE
setup reproducibility and created independent index.md

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,6 +7,9 @@ end
 
 using MuladdMacro
 
+cp("./docs/Manifest.toml", "./docs/src/assets/Manifest.toml", force = true)
+cp("./docs/Project.toml", "./docs/src/assets/Project.toml", force = true)
+
 makedocs(;
          modules = [MuladdMacro],
          repo = "https://github.com/SciML/MuladdMacro.jl/blob/{commit}{path}#{line}",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,8 +7,8 @@ end
 
 using MuladdMacro
 
-cp("./docs/Manifest.toml", "./docs/src/assets/Manifest.toml", force = true)
-cp("./docs/Project.toml", "./docs/src/assets/Project.toml", force = true)
+cp(joinpath(@__DIR__, "Manifest.toml"), joinpath(@__DIR__, "src/assets/Manifest.toml"); force = true)
+cp(joinpath(@__DIR__, "Project.toml"), joinpath(@__DIR__, "src/assets/Project.toml"); force = true)
 
 makedocs(;
          modules = [MuladdMacro],

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,1 +1,117 @@
-../../README.md
+# MuladdMacro.jl
+
+This package provides the `@muladd` macro. It automatically converts expressions
+with multiplications and additions or subtractions to calls with `muladd` which then fuse via
+FMA when it would increase the performance of the code. The `@muladd` macro
+can be placed on code blocks and it will automatically find the appropriate
+expressions and nest muladd expressions when necessary. In mixed expressions summands without multiplication 
+will be grouped together and evaluated first but otherwise the order of evaluation of multiplications and additions is not changed.
+
+## Tutorials and Documentation
+
+For information on using the package,
+[see the stable documentation](https://docs.sciml.ai/MuladdMacro/stable/). Use the
+[in-development documentation](https://docs.sciml.ai/MuladdMacro/dev/) for the version of
+the documentation, which contains the unreleased features.
+
+## Examples
+
+```jldoctest
+julia> using MuladdMacro
+
+julia> @macroexpand(@muladd k3 = f(t + c3*dt, @. uprev+dt*(a031*k1+a032*k2)))
+:(k3 = f((muladd)(c3, dt, t), (muladd).(dt, (muladd).(a032, k2, (*).(a031, k1)), uprev)))
+
+julia> @macroexpand(@muladd integrator.EEst = integrator.opts.internalnorm((update - dt*(bhat1*k1 + bhat4*k4 + bhat5*k5 + bhat6*k6 + bhat7*k7 + bhat10*k10))./ @. (integrator.opts.abstol+max(abs(uprev),abs(u))*integrator.opts.reltol)))
+:(integrator.EEst = integrator.opts.internalnorm((muladd)(-dt, (muladd)(bhat10, k10, (muladd)(bhat7, k7, (muladd)(bhat6, k6, (muladd)(bhat5, k5, (muladd)(bhat4, k4, bhat1 * k1))))), update) ./ (muladd).(max.(abs.(uprev), abs.(u)), integrator.opts.reltol, integrator.opts.abstol)))
+```
+
+## Broadcasting
+
+A `muladd` call will be broadcasted if both the `*` and the `+` or `-` are broadcasted.
+If either one is not broadcasted, then the expression will be converted to a
+non-dotted `muladd`.
+
+## Limitations
+
+Currently, `@muladd` handles only explicit calls of `+` and `*`. In particular, assignments
+using `+=` or literal power such as `^2` are not supported. Thus, you need to rewrite them, e.g.
+```jldoctest
+julia> using MuladdMacro
+
+julia> a = 1.0; b = 2.0; c = 3.0;
+
+julia> @macroexpand @muladd a += b * c # does not work
+:(a += b * c)
+
+julia> @macroexpand @muladd a = a + b * c # good alternative
+:(a = (muladd)(b, c, a))
+
+julia> @macroexpand @muladd a + b^2 # does not work
+:(a + b ^ 2)
+
+julia> @macroexpand @muladd a + b * b # good alternative
+:((muladd)(b, b, a))
+```
+
+## Credit
+
+Most of the credit goes to @fcard and @devmotion for building the first version
+and greatly refining the macro. These contributions are not directly shown as
+this was developed in Gitter chats and in the DiffEqBase.jl repository, but
+these two individuals did almost all of the work.
+
+## Reproducibility
+```@raw html
+<details><summary>The documentation of this SciML package was built using these direct dependencies,</summary>
+```
+```@example
+using Pkg # hide
+Pkg.status() # hide
+```
+```@raw html
+</details>
+```
+```@raw html
+<details><summary>and using this machine and Julia version.</summary>
+```
+```@example
+using InteractiveUtils # hide
+versioninfo() # hide
+```
+```@raw html
+</details>
+```
+```@raw html
+<details><summary>A more complete overview of all dependencies and their versions is also provided.</summary>
+```
+```@example
+using Pkg # hide
+Pkg.status(;mode = PKGMODE_MANIFEST) # hide
+```
+```@raw html
+</details>
+```
+```@raw html
+You can also download the 
+<a href="
+```
+```@eval
+using TOML
+version = TOML.parse(read("../../Project.toml",String))["version"]
+name = TOML.parse(read("../../Project.toml",String))["name"]
+link = "https://github.com/SciML/"*name*".jl/tree/gh-pages/v"*version*"/assets/Manifest.toml"
+```
+```@raw html
+">manifest</a> file and the
+<a href="
+```
+```@eval
+using TOML
+version = TOML.parse(read("../../Project.toml",String))["version"]
+name = TOML.parse(read("../../Project.toml",String))["name"]
+link = "https://github.com/SciML/"*name*".jl/tree/gh-pages/v"*version*"/assets/Project.toml"
+```
+```@raw html
+">project</a> file.
+```


### PR DESCRIPTION
This was a marginally more involved change. In the original repo, the `index.md` file was setup as a symbolic link to the README file. So I could not add reproducibility to the `index.md` file, without also changing the README. Since changing the README was inconsistent with the standard, I talked to Arno and he suggested I just remove the symbolic link and create an independent `index.md`, which is what I did. 

Beyond that, just added the usual reproducibility stuff:

- updated index.md with reproducibility code
- updated make.jl
- confirmed "built" not "build".
- README unchanged.