### PR TITLE
enable dependabot for GitHub actions

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,8 +7,10 @@ end
 
 using MuladdMacro
 
-cp(joinpath(@__DIR__, "Manifest.toml"), joinpath(@__DIR__, "src/assets/Manifest.toml"); force = true)
-cp(joinpath(@__DIR__, "Project.toml"), joinpath(@__DIR__, "src/assets/Project.toml"); force = true)
+cp(joinpath(@__DIR__, "Manifest.toml"), joinpath(@__DIR__, "src/assets/Manifest.toml");
+   force = true)
+cp(joinpath(@__DIR__, "Project.toml"), joinpath(@__DIR__, "src/assets/Project.toml");
+   force = true)
 
 makedocs(;
          modules = [MuladdMacro],


### PR DESCRIPTION
This allows us to get updates for GitHub actions automatically. I have used this for my own packages as well as our [Trixi.jl framework](https://github.com/trixi-framework). After merging this, we should also enable other Dependabot actions in "Settings -> Code security and analysis -> Dependabot alerts" and "... -> Dependabot security updates".

After merging this, Dependabot will prepare PRs with updates of the versions of GitHub actions we use such as.

I think it would be nice to have this in all of SciML. To get the discussion started, I picked this repo since the CI tests are not very expensive.