### PR TITLE
Add codecov token

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,4 +35,5 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }} # required
           files: lcov.info

--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -25,4 +25,5 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }} # required
           file: lcov.info


### PR DESCRIPTION
The PR fixes the codecov integration: v4 of the action requires the codecov token (tokenless uploads are not supported anymore, see https://github.com/codecov/codecov-action?tab=readme-ov-file#v4-release).
