### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"
       - "/docs"
-      - "/test"
     schedule:
       interval: "daily"
     groups:

--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -9,21 +9,5 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@latest
-        with:
-          version: '1'
-      - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
-      - name: Build and deploy
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key
-        run: julia --project=docs/ --code-coverage=user docs/make.jl
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v6
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }} # required
-          files: lcov.info
+    uses: "SciML/.github/.github/workflows/documentation.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -12,15 +12,7 @@ on:
       - 'docs/**'
 jobs:
   test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
-        id: setup-julia
-        with:
-          version: '1'
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          julia_version: ${{ steps['setup-julia'].outputs.julia-version }}
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,5 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,5 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.17.0 
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Converts the remaining inline CI jobs to the centralized SciML/.github reusable workflows, pinned `@v1`, each caller given `secrets: "inherit"`.

## Converted (inline -> central caller)
- **Docs.yml** (Documentation): inline Documenter build/deploy + coverage -> `documentation.yml@v1`. Coverage behavior preserved (the central workflow runs `--code-coverage=user` and reports to Codecov).
- **Downgrade.yml**: inline `julia-downgrade-compat` -> `downgrade.yml@v1`. The original ran on Julia `"1"`, so `julia-version: "1"` is set (rather than the central default `lts`) to preserve behavior exactly. `skip`/`projects` left at defaults (`Pkg,TOML` / `.`) matching the original single-project downgrade.
- **FormatCheck.yml** (Runic): inline `fredrikekre/runic-action` -> `runic.yml@v1`.
- **SpellCheck.yml** (typos): inline `crate-ci/typos` -> `spellcheck.yml@v1`.

## Already central (unchanged behavior)
- **Tests.yml**: already a `tests.yml@v1` caller with `secrets: "inherit"`; version matrix `["1","lts","pre"]` preserved.

## Unchanged
- TagBot.yml, DocsPreviewCleanup.yml left as-is.

## dependabot.yml
- Removed the `crate-ci/typos` version-ignore (spellcheck is now centralized).
- Kept the `julia` block but dropped `/test` (no `test/Project.toml` exists); now `/` and `/docs`.
- `github-actions` weekly + `julia` daily (group `all-julia-packages: ["*"]`) preserved.

## Formatting / spelling
- Runic (v1) run in place: no `.jl` changes (repo was already Runic-clean from the inline check).
- `typos .` already clean (exit 0); **0 typos fixed**. Existing `.typos.toml` left untouched.

## Note on required checks
Job/check names change with the reusable workflows (e.g. the Runic job now reports as "Runic Format Check", docs as "Build and Deploy Documentation", spellcheck as "Spell Check with Typos", downgrade as "Downgrade Tests"). **Branch-protection required-status-check names will need updating** to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)