### PR TITLE
Canonicalize tests to @safetestset for module isolation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ Aqua = "0.8.4"
 ExplicitImports = "1.14.0"
 JET = "0.9.8, 0.10, 0.11.2"
 PrecompileTools = "1"
+SafeTestsets = "0.1, 1"
 Test = "1.0.0"
 julia = "1.10"
 
@@ -20,7 +21,8 @@ Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["AllocCheck", "Aqua", "ExplicitImports", "JET", "Pkg", "Test"]
+test = ["AllocCheck", "Aqua", "ExplicitImports", "JET", "Pkg", "SafeTestsets", "Test"]

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -3,6 +3,7 @@ Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
@@ -12,5 +13,6 @@ MuladdMacro = {path = "../.."}
 Aqua = "0.8.4"
 ExplicitImports = "1.14.0"
 JET = "0.9.8, 0.10, 0.11.2"
+SafeTestsets = "0.1, 1"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,6 +1,7 @@
-using MuladdMacro, Aqua, ExplicitImports, JET, Test
+using SafeTestsets
 
-@testset "Aqua" begin
+@safetestset "Aqua" begin
+    using MuladdMacro, Aqua, Test
     # deps_compat check_extras is known failing (Pkg extra lacks a compat entry)
     # and is marked @test_broken below.
     # Tracked in https://github.com/SciML/MuladdMacro.jl/issues/88
@@ -13,12 +14,14 @@ using MuladdMacro, Aqua, ExplicitImports, JET, Test
     @test_broken false
 end
 
-@testset "ExplicitImports" begin
+@safetestset "ExplicitImports" begin
+    using MuladdMacro, ExplicitImports, Test
     @test check_no_implicit_imports(MuladdMacro) === nothing
     @test check_no_stale_explicit_imports(MuladdMacro) === nothing
 end
 
-@testset "JET static analysis" begin
+@safetestset "JET static analysis" begin
+    using MuladdMacro, JET, Test
     rep = JET.report_call(MuladdMacro.to_muladd, (Expr,))
     @test isempty(JET.get_reports(rep))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Pkg
-using MuladdMacro, Test
+using MuladdMacro, SafeTestsets, Test
 
 const GROUP = get(ENV, "GROUP", "All")
 
@@ -12,7 +12,8 @@ end
 
 if GROUP == "All" || GROUP == "Core"
     # Basic expressions
-    @testset "Basic expressions" begin
+    @safetestset "Basic expressions" begin
+        using MuladdMacro, Test
         @testset "Summation" begin
             @test @macroexpand(@muladd a * b + c) == :($(Base.muladd)(a, b, c))
             @test @macroexpand(@muladd c + a * b) == :($(Base.muladd)(a, b, c))
@@ -29,7 +30,8 @@ if GROUP == "All" || GROUP == "Core"
     end
 
     # Additional factors
-    @testset "Additional factors" begin
+    @safetestset "Additional factors" begin
+        using MuladdMacro, Test
         @testset "Summation" begin
             @test @macroexpand(@muladd a * b * c + d) == :($(Base.muladd)(a * b, c, d))
             @test @macroexpand(@muladd a * b * c * d + e) == :($(Base.muladd)(a * b * c, d, e))
@@ -45,7 +47,8 @@ if GROUP == "All" || GROUP == "Core"
     end
 
     # Multiple multiplications
-    @testset "Multiple multiplications" begin
+    @safetestset "Multiple multiplications" begin
+        using MuladdMacro, Test
         @testset "Summation" begin
             @test @macroexpand(@muladd a * b + c * d) == :($(Base.muladd)(c, d, a * b))
             @test @macroexpand(@muladd a * b + c * d + e * f) ==
@@ -66,7 +69,8 @@ if GROUP == "All" || GROUP == "Core"
     end
 
     # Dot calls
-    @testset "Dot calls" begin
+    @safetestset "Dot calls" begin
+        using MuladdMacro, Test
         @testset "Summation" begin
             @test @macroexpand(@. @muladd a * b + c) == :($(Base.muladd).(a, b, c))
             @test @macroexpand(@muladd @. a * b + c) == :($(Base.muladd).(a, b, c))
@@ -100,7 +104,8 @@ if GROUP == "All" || GROUP == "Core"
     end
 
     # Nested expressions
-    @testset "Nested expressions" begin
+    @safetestset "Nested expressions" begin
+        using MuladdMacro, Test
         @test Base.remove_linenums!(@macroexpand(@muladd f(x, y, z) = x * y + z)) ==
             Base.remove_linenums!(:(f(x, y, z) = $(Base.muladd)(x, y, z)))
         @test Base.remove_linenums!(
@@ -136,7 +141,8 @@ if GROUP == "All" || GROUP == "Core"
     end
 
     # Test to_muladd export and functionality
-    @testset "to_muladd function" begin
+    @safetestset "to_muladd function" begin
+        using MuladdMacro, Test
         # Test that to_muladd is exported
         @test isdefined(MuladdMacro, :to_muladd)
         @test to_muladd === MuladdMacro.to_muladd
@@ -158,7 +164,8 @@ if GROUP == "All" || GROUP == "Core"
     end
 
     # Test include with to_muladd transformation
-    @testset "include with to_muladd" begin
+    @safetestset "include with to_muladd" begin
+        using MuladdMacro, Test
         # Create a temporary file to test include(to_muladd, "file.jl")
         testfile = tempname() * ".jl"
         try
@@ -181,7 +188,7 @@ if GROUP == "All" || GROUP == "Core"
     end
 
     # Allocation tests - run in separate group to avoid interference with precompilation
-    @testset "Allocation Tests" begin
+    @safetestset "Allocation Tests" begin
         include("alloc_tests.jl")
     end
 end


### PR DESCRIPTION
## What

Wrap each independent test unit in `@safetestset` so it runs in its own module, matching the canonical OrdinaryDiffEq test structure (isolation between tests + world-age safety).

### Core (`test/runtests.jl`)
Each top-level `@testset` unit becomes `@safetestset` with its own `using MuladdMacro, Test`:
- Basic expressions, Additional factors, Multiple multiplications, Dot calls, Nested expressions, to_muladd function, include with to_muladd.
- These use `@macroexpand(@muladd ...)`, where `@muladd` resolves at runtime inside `@macroexpand`, so inline bodies work (no `include()` trick needed).
- **Allocation Tests** keeps the `include("alloc_tests.jl")` form: it uses `@check_allocs`/`@muladd` directly (expanded at body-macroexpansion time, so the imports must run first via sequential `include`). `alloc_tests.jl` already carries its own `using` lines.
- Inner grouping `@testset`s ("Summation"/"Subtraction") stay plain — the unit-level `@safetestset` already isolates.

### QA (`test/qa/qa.jl`)
The three plain `@testset` units (Aqua, ExplicitImports, JET static analysis) become `@safetestset`, each with its own `using`.

### Deps
- `SafeTestsets` added to the main `Project.toml` `[extras]`/`[targets].test`/`[compat]` (`SafeTestsets = "0.1, 1"`).
- `SafeTestsets` added to `test/qa/Project.toml` (the QA group activates its own env).

## Verification
Behavior-preserving: same tests run under the same GROUP dispatch, same assertions; only the unit wrappers and self-containing imports changed.

Verified locally on Julia 1.11:
- `GROUP=Core`: all units pass (Basic 8, Additional 6, Multiple 7, Dot 20, Nested 3, to_muladd 9, include-with-to_muladd 1, Allocation 5).
- `GROUP=QA`: Aqua 10 pass + 1 broken (pre-existing), ExplicitImports 2, JET 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
This PR is a draft. Ignore until reviewed by @ChrisRackauckas.