### PR TITLE
QA: run_qa v1.6 form + ExplicitImports

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 
 [compat]
 AllocCheck = "0.2"
-PrecompileTools = "1"
+PrecompileTools = "1.0.1"
 SafeTestsets = "0.1, 1"
 SciMLTesting = "1.6"
 Test = "1.0.0"

--- a/Project.toml
+++ b/Project.toml
@@ -7,23 +7,17 @@ PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 
 [compat]
 AllocCheck = "0.2"
-Aqua = "0.8.4"
-ExplicitImports = "1.14.0"
-JET = "0.9.8, 0.10, 0.11.2"
 PrecompileTools = "1"
 SafeTestsets = "0.1, 1"
-SciMLTesting = "1"
+SciMLTesting = "1.6"
 Test = "1.0.0"
 julia = "1.10"
 
 [extras]
 AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
-Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
-JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["AllocCheck", "Aqua", "ExplicitImports", "JET", "SafeTestsets", "SciMLTesting", "Test"]
+test = ["AllocCheck", "SafeTestsets", "SciMLTesting", "Test"]

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,6 +1,5 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
@@ -12,9 +11,8 @@ MuladdMacro = {path = "../.."}
 
 [compat]
 Aqua = "0.8.4"
-ExplicitImports = "1.14.0"
 JET = "0.9.8, 0.10, 0.11.2"
 SafeTestsets = "0.1, 1"
-SciMLTesting = "1"
+SciMLTesting = "1.6"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,30 +1,7 @@
-using MuladdMacro, Aqua, ExplicitImports, JET, Test
+using SciMLTesting, JET, MuladdMacro, Test
 
-@testset "Aqua" begin
-    Aqua.test_all(
-        MuladdMacro;
-        ambiguities = (recursive = false,)
-    )
-end
-
-@testset "ExplicitImports" begin
-    @test check_no_implicit_imports(MuladdMacro) === nothing
-    @test check_no_stale_explicit_imports(MuladdMacro) === nothing
-end
-
-@testset "JET static analysis" begin
-    rep = JET.report_call(MuladdMacro.to_muladd, (Expr,))
-    @test isempty(JET.get_reports(rep))
-
-    rep = JET.report_call(MuladdMacro.sum_to_muladd, (Expr,))
-    @test isempty(JET.get_reports(rep))
-
-    rep = JET.report_call(MuladdMacro.sub_to_muladd, (Expr,))
-    @test isempty(JET.get_reports(rep))
-
-    rep = JET.report_call(MuladdMacro.issum, (Expr,))
-    @test isempty(JET.get_reports(rep))
-
-    rep = JET.report_call(MuladdMacro.issub, (Expr,))
-    @test isempty(JET.get_reports(rep))
-end
+run_qa(
+    MuladdMacro;
+    explicit_imports = true,
+    aqua_kwargs = (; ambiguities = (recursive = false,)),
+)


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

Brings MuladdMacro's QA group onto the SciMLTesting 1.6 `run_qa` form with ExplicitImports enabled (Phase 4: manual/hand-rolled QA -> run_qa).

### `test/qa/qa.jl`
```julia
using SciMLTesting, JET, MuladdMacro, Test

run_qa(
    MuladdMacro;
    explicit_imports = true,
    aqua_kwargs = (; ambiguities = (recursive = false,)),
)
```
- Aqua + ExplicitImports come from SciMLTesting's own deps; JET is opt-in via `using JET`.
- The Aqua `ambiguities = (recursive = false,)` tweak is preserved.
- The previous hand-rolled JET `report_call` on 5 internal functions is replaced by `run_qa`'s canonical whole-package `test_package(MuladdMacro; target_modules = (MuladdMacro,), mode = :typo)` (broader coverage).

### ExplicitImports findings
All 6 ExplicitImports checks pass **clean** with no findings against MuladdMacro (it only `using PrecompileTools: @setup_workload, @compile_workload` explicitly and otherwise uses Base names). No `ei_kwargs` ignores, no `ei_broken`, no `aqua_broken`, no `jet_broken` are needed. The original hand-rolled qa.jl had no `@test_broken` to preserve.

| EI check | result |
|---|---|
| `no_implicit_imports` | pass |
| `no_stale_explicit_imports` | pass |
| `all_explicit_imports_via_owners` | pass |
| `all_qualified_accesses_via_owners` | pass |
| `all_qualified_accesses_are_public` | pass |
| `all_explicit_imports_are_public` | pass |

### Deps
- `test/qa/Project.toml`: drop `ExplicitImports` (transitive via SciMLTesting); keep `Aqua` (the `ambiguities` sub-check's child process needs Aqua a direct dep) and `JET` (runs); bump `SciMLTesting` compat floor to `"1.6"`.
- Root `Project.toml`: drop now-dead `Aqua`/`ExplicitImports`/`JET` from `[extras]`/`[targets].test`/`[compat]` (QA runs in its own `test/qa` sub-env under the `run_tests()` folder model; Core only uses `AllocCheck` + `MuladdMacro` + `Test`); bump `SciMLTesting` to `"1.6"`. This stops the Core lane from precompiling Aqua/JET/ExplicitImports.

### Local verification (Julia 1.10, released SciMLTesting 1.6.0, not dev-from-branch)
- QA group via `GROUP=QA Pkg.test()`: `QA/qa.jl | 18 pass / 18 total`, 0 fail/error/broken.
- Core via `GROUP=Core Pkg.test()`: `Core/alloc_tests.jl 5/5`, `Core/core_tests.jl 54/54`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)